### PR TITLE
Adding filter to format_menu_item

### DIFF
--- a/lib/wp-api-menus.php
+++ b/lib/wp-api-menus.php
@@ -267,7 +267,7 @@ if ( ! class_exists( 'WP_JSON_Menus' ) ) :
 			if ( $children === true && ! empty( $menu ) )
 				$menu_item['children'] = $this->get_nav_menu_item_children( $item['ID'], $menu );
 
-			return $menu_item;
+			return apply_filters('format_menu_item', $menu_item);
 		}
 
 	}


### PR DESCRIPTION
Adding a wordpress filter to format_menu_item that allows developers to
hook into the function to format the data before it gets returned.

For example:

function formatMenuItem($menu_item) {
    $menu_item['title'] = ucwords($menu_item['title']);
    return $menu_item;
}

add_filter('format_menu_item', 'formatMenuItem');

I needed this for a Angular / Wordpress integration where the URL was pulling in the full path and I only needed the relative.