### PR TITLE
Add items argument to menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,21 @@
 #### New routes available:
 
 - `/menus` list of every registered menu.
+  - (V2 only:) `item` argument whether to fetch the menu items. Default: `false`
 - `/menus/<id>` data for a specific menu.
 - `/menu-locations` list of all registered theme locations.
-- `/menu-locations/<location>` data for menu in specified menu in theme location. 
+- `/menu-locations/<location>` data for menu in specified menu in theme location.
 
 Currently, the `menu-locations/<location>` route for individual menus will return a tree with full menu hierarchy, with correct menu item order and listing children for each menu item. The `menus/<id>` route will output menu details and a flat array of menu items. Item order or if each item has a parent will be indicated in each item attributes, but this route won't output items as a tree.
- 
+
 You can alter the data arrangement of each individual menu items and children using the filter hook `json_menus_format_menu_item`.
 
 #### WP API V2
 
 In V1 of the REST API the routes are located by default at `wp-json/menus/` etc.
 
-In V2 the routes by default are at `wp-json/wp-api-menus/v2/` (e.g. `wp-json/wp-api-menus/v2/menus/`, etc.) since V2 encourages prefixing and version namespacing. 
+In V2 the routes by default are at `wp-json/wp-api-menus/v2/` (e.g. `wp-json/wp-api-menus/v2/menus/`, etc.) since V2 encourages prefixing and version namespacing.
 
 #### Contributing
 
-* Submit a pull request or open a ticket here on GitHub. 
+* Submit a pull request or open a ticket here on GitHub.

--- a/includes/wp-api-menus-v1.php
+++ b/includes/wp-api-menus-v1.php
@@ -274,6 +274,7 @@ if ( ! class_exists( 'WP_JSON_Menus' ) ) :
 				'description' => $item['description'],
 				'object_id'   => abs( $item['object_id'] ),
 				'object'      => $item['object'],
+                'object_slug' => get_post($item['object_id'])->post_name,
 				'type'        => $item['type'],
 				'type_label'  => $item['type_label'],
 			);

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -302,9 +302,9 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 				if ( array_key_exists ( $item->ID , $cache ) ) {
 					$formatted['children'] = array_reverse ( $cache[ $item->ID ] );
 				}
-				
+
             	$formatted = apply_filters( 'rest_menus_format_menu_item', $formatted );
-				
+
 				if ( $item->menu_item_parent != 0 ) {
 					// Wait for parent to pick me up
 					if ( array_key_exists ( $item->menu_item_parent , $cache ) ) {
@@ -379,6 +379,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 'description' => $item['description'],
                 'object_id'   => abs( $item['object_id'] ),
                 'object'      => $item['object'],
+                'object_slug' => get_post($item['object_id'])->post_name,
                 'type'        => $item['type'],
                 'type_label'  => $item['type_label'],
             );

--- a/readme.txt
+++ b/readme.txt
@@ -17,6 +17,7 @@ This plugin extends the [WordPress JSON REST API](https://wordpress.org/plugins/
 The new routes available will be:
 
 * `/menus` list of every registered menu.
+  * (V2 only:) `item` argument whether to fetch the menu items. Default: `false`
 * `/menus/<id>` data for a specific menu.
 * `/menu-locations` list of all registered theme locations.
 * `/menu-locations/<location>` data for menu in specified menu in theme location.
@@ -90,7 +91,7 @@ Nothing to show really, this plugin has no settings or frontend, it just extends
 = 1.1.0 =
 * Enhancement: Routes for menus in theme locations now include complete tree with item order and nested children
 * Tweak: `description` attribute for individual items is now included in results
-* Fix: Fixed typo confusing `parent` with `collection` in meta   
+* Fix: Fixed typo confusing `parent` with `collection` in meta
 
 = 1.0.0 =
 * First public release


### PR DESCRIPTION
In some cases the cost of fetching the menus first and then only fetching the items for the menus that are needed by id are higher then fetching them all at once. It's now possible to specify an `items` argument to indicate whether to fetch the menu items as well or not.

Since it defaults to false this change would be non breaking.

Note that this change is currently V2 only.
