### PR TITLE
Get menu by id name and slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 - `/menus` list of every registered menu.
   - (V2 only:) `item` argument whether to fetch the menu items. Default: `false`
-- `/menus/<id>` data for a specific menu.
+- `/menus/<menu>` data for a specific menu. Takes either an id, a name or a slug. Note that v1 only supports ids.
 - `/menu-locations` list of all registered theme locations.
 - `/menu-locations/<location>` data for menu in specified menu in theme location.
 

--- a/README.md
+++ b/README.md
@@ -11,20 +11,21 @@
 #### New routes available:
 
 - `/menus` list of every registered menu.
+  - (V2 only:) `item` argument whether to fetch the menu items. Default: `false`
 - `/menus/<id>` data for a specific menu.
 - `/menu-locations` list of all registered theme locations.
-- `/menu-locations/<location>` data for menu in specified menu in theme location. 
+- `/menu-locations/<location>` data for menu in specified menu in theme location.
 
 Currently, the `menu-locations/<location>` route for individual menus will return a tree with full menu hierarchy, with correct menu item order and listing children for each menu item. The `menus/<id>` route will output menu details and a flat array of menu items. Item order or if each item has a parent will be indicated in each item attributes, but this route won't output items as a tree.
- 
+
 You can alter the data arrangement of each individual menu items and children using the filter hook `json_menus_format_menu_item`.
 
 #### WP API V2
 
 In V1 of the REST API the routes are located by default at `wp-json/menus/` etc.
 
-In V2 the routes by default are at `wp-json/wp-api-menus/v2/` (e.g. `wp-json/wp-api-menus/v2/menus/`, etc.) since V2 encourages prefixing and version namespacing. 
+In V2 the routes by default are at `wp-json/wp-api-menus/v2/` (e.g. `wp-json/wp-api-menus/v2/menus/`, etc.) since V2 encourages prefixing and version namespacing.
 
 #### Contributing
 
-* Submit a pull request or open a ticket here on GitHub. 
+* Submit a pull request or open a ticket here on GitHub.

--- a/includes/wp-api-menus-v1.php
+++ b/includes/wp-api-menus-v1.php
@@ -274,6 +274,7 @@ if ( ! class_exists( 'WP_JSON_Menus' ) ) :
 				'description' => $item['description'],
 				'object_id'   => abs( $item['object_id'] ),
 				'object'      => $item['object'],
+                'object_slug' => get_post($item['object_id'])->post_name,
 				'type'        => $item['type'],
 				'type_label'  => $item['type_label'],
 			);

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -176,7 +176,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 
                 $rest_menu['items']                       = $rest_menu_items;
                 $rest_menu['meta']['links']['collection'] = $rest_url;
-                $rest_menu['meta']['links']['self']       = $rest_url . $id;
+                $rest_menu['meta']['links']['self']       = $rest_url . $menu;
 
             endif;
 

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -302,9 +302,9 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 				if ( array_key_exists ( $item->ID , $cache ) ) {
 					$formatted['children'] = array_reverse ( $cache[ $item->ID ] );
 				}
-				
+
             	$formatted = apply_filters( 'rest_menus_format_menu_item', $formatted );
-				
+
 				if ( $item->menu_item_parent != 0 ) {
 					// Wait for parent to pick me up
 					if ( array_key_exists ( $item->menu_item_parent , $cache ) ) {
@@ -379,6 +379,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 'description' => $item['description'],
                 'object_id'   => abs( $item['object_id'] ),
                 'object'      => $item['object'],
+                'object_slug' => get_post($item['object_id'])->post_name,
                 'type'        => $item['type'],
                 'type_label'  => $item['type_label'],
             );

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -176,7 +176,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 
                 $rest_menu['items']                       = $rest_menu_items;
                 $rest_menu['meta']['links']['collection'] = $rest_url;
-                $rest_menu['meta']['links']['self']       = $rest_url . $menu;
+                $rest_menu['meta']['links']['self']       = $rest_url . abs( $menu['term_id'] );
 
             endif;
 

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 )
             ) );
 
-            register_rest_route( self::get_plugin_namespace(), '/menus/(?P<id>\d+)', array(
+            register_rest_route( self::get_plugin_namespace(), '/menus/(?P<menu>[a-zA-Z0-9_-]+)', array(
                 array(
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu' ),
@@ -151,10 +151,10 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          */
         public function get_menu( $request ) {
 
-            $id             = (int) $request['id'];
+            $menu           = (string) $request['menu'];
             $rest_url       = get_rest_url() . self::get_api_namespace() . '/menus/';
-            $wp_menu_object = $id ? wp_get_nav_menu_object( $id ) : array();
-            $wp_menu_items  = $id ? wp_get_nav_menu_items( $id ) : array();
+            $wp_menu_object = $menu ? wp_get_nav_menu_object( $menu ) : array();
+            $wp_menu_items  = $menu ? wp_get_nav_menu_items( $menu ) : array();
 
             $rest_menu = array();
 

--- a/readme.txt
+++ b/readme.txt
@@ -17,6 +17,7 @@ This plugin extends the [WordPress JSON REST API](https://wordpress.org/plugins/
 The new routes available will be:
 
 * `/menus` list of every registered menu.
+  * (V2 only:) `item` argument whether to fetch the menu items. Default: `false`
 * `/menus/<id>` data for a specific menu.
 * `/menu-locations` list of all registered theme locations.
 * `/menu-locations/<location>` data for menu in specified menu in theme location.
@@ -90,7 +91,7 @@ Nothing to show really, this plugin has no settings or frontend, it just extends
 = 1.1.0 =
 * Enhancement: Routes for menus in theme locations now include complete tree with item order and nested children
 * Tweak: `description` attribute for individual items is now included in results
-* Fix: Fixed typo confusing `parent` with `collection` in meta   
+* Fix: Fixed typo confusing `parent` with `collection` in meta
 
 = 1.0.0 =
 * First public release

--- a/readme.txt
+++ b/readme.txt
@@ -18,7 +18,7 @@ The new routes available will be:
 
 * `/menus` list of every registered menu.
   * (V2 only:) `item` argument whether to fetch the menu items. Default: `false`
-* `/menus/<id>` data for a specific menu.
+* `/menus/<menu>` data for a specific menu. Takes either an id, a name or a slug. Note that v1 only supports ids.
 * `/menu-locations` list of all registered theme locations.
 * `/menu-locations/<location>` data for menu in specified menu in theme location.
 


### PR DESCRIPTION
Changed /menus/<id> to /menus/<menus> to take all supported param types of [wp_get_nav_menu_object](https://developer.wordpress.org/reference/functions/wp_get_nav_menu_object/) and [wp_get_nav_menu_items](https://developer.wordpress.org/reference/functions/wp_get_nav_menu_object/). This makes the slug filter argument suggested in 6b03a18 obsolete.

Note that this is currently V2 only.
