### PR TITLE
Replace isset() with empty() check

### DIFF
--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -267,7 +267,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
             $location   = $params['location'];
             $locations  = get_nav_menu_locations();
 
-            if ( ! isset( $locations[ $location ] ) ) {
+            if ( empty( $locations[ $location ] ) ) {
 	            return array();
             }
 


### PR DESCRIPTION
When the menu is not assigned to the menu location, it returns 0 and generates a PHP warning `Invalid argument supplied for foreach()`. It will become a fatal error in PHP8.